### PR TITLE
feat: Adapt window controls for macOS platform

### DIFF
--- a/src/main/ipcHandlers.ts
+++ b/src/main/ipcHandlers.ts
@@ -78,6 +78,10 @@ export function setupIpcHandlers(): void {
     return window ? window.isMaximized() : false
   })
 
+  ipcMain.handle('window-get-platform', () => {
+    return process.platform
+  })
+
   // Handle save file
   ipcMain.handle('save-file', async (event, { content, defaultPath, filters }) => {
     try {

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -21,8 +21,16 @@ export function createWindow(): void {
     minHeight: 320,
     show: false,
     autoHideMenuBar: true,
-    frame: false, // 禁用默认边框，启用自定义标题栏
-    titleBarStyle: 'hidden', // 隐藏标题栏
+    // macOS 使用原生窗口控制按钮，其他平台使用自定义
+    ...(process.platform === 'darwin'
+      ? {
+          titleBarStyle: 'hiddenInset', // macOS: 显示原生控制按钮
+          trafficLightPosition: { x: 10, y: 10 } // 调整原生按钮位置
+        }
+      : {
+          frame: false, // Windows/Linux: 完全自定义
+          titleBarStyle: 'hidden'
+        }),
     ...(process.platform === 'linux' ? { icon } : {}),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -88,7 +88,8 @@ const windowAPI = {
   minimize: () => ipcRenderer.invoke('window-minimize'),
   maximize: () => ipcRenderer.invoke('window-maximize'),
   close: () => ipcRenderer.invoke('window-close'),
-  isMaximized: () => ipcRenderer.invoke('window-is-maximized')
+  isMaximized: () => ipcRenderer.invoke('window-is-maximized'),
+  getPlatform: () => ipcRenderer.invoke('window-get-platform')
 }
 
 // Use `contextBridge` APIs to expose Electron APIs to

--- a/src/renderer/src/components/layout/titlebar/TitleBar.tsx
+++ b/src/renderer/src/components/layout/titlebar/TitleBar.tsx
@@ -18,18 +18,21 @@ interface TitleBarProps {
 
 export default function TitleBar({ title, sidebarCollapsed, onToggleSidebar }: TitleBarProps) {
   const [isMaximized, setIsMaximized] = useState(false)
+  const [isMac, setIsMac] = useState(false)
 
   useEffect(() => {
-    // 检查窗口状态
-    const checkMaximized = async () => {
+    const init = async () => {
       try {
+        const platform = await (window as any).electronWindow.getPlatform()
+        setIsMac(platform === 'darwin')
+
         const maximized = await (window as any).electronWindow.isMaximized()
         setIsMaximized(maximized)
       } catch (error) {
-        console.error('Error checking maximized state:', error)
+        console.error('Error initializing titlebar:', error)
       }
     }
-    checkMaximized()
+    init()
   }, [])
 
   const handleMinimize = async () => {
@@ -59,7 +62,7 @@ export default function TitleBar({ title, sidebarCollapsed, onToggleSidebar }: T
   }
 
   return (
-    <div className="custom-title-bar">
+    <div className={`custom-title-bar ${isMac ? 'mac' : ''}`}>
       <div className="title-bar-drag-region">
         <div className="title-bar-left">
           <Tooltip title={sidebarCollapsed ? '展开侧边栏' : '收起侧边栏'}>
@@ -72,32 +75,34 @@ export default function TitleBar({ title, sidebarCollapsed, onToggleSidebar }: T
           </Tooltip>
           <h2 className="title-bar-title">{title}</h2>
         </div>
-        <div className="title-bar-right">
-          <Tooltip title="最小化">
-            <Button
-              type="text"
-              icon={<MinusOutlined />}
-              onClick={handleMinimize}
-              className="title-bar-control-button"
-            />
-          </Tooltip>
-          <Tooltip title={isMaximized ? '还原' : '最大化'}>
-            <Button
-              type="text"
-              icon={isMaximized ? <CopyOutlined /> : <BorderOutlined />}
-              onClick={handleMaximize}
-              className="title-bar-control-button"
-            />
-          </Tooltip>
-          <Tooltip title="关闭">
-            <Button
-              type="text"
-              icon={<CloseOutlined />}
-              onClick={handleClose}
-              className="title-bar-control-button title-bar-close-button"
-            />
-          </Tooltip>
-        </div>
+        {!isMac && (
+          <div className="title-bar-right">
+            <Tooltip title="最小化">
+              <Button
+                type="text"
+                icon={<MinusOutlined />}
+                onClick={handleMinimize}
+                className="title-bar-control-button"
+              />
+            </Tooltip>
+            <Tooltip title={isMaximized ? '还原' : '最大化'}>
+              <Button
+                type="text"
+                icon={isMaximized ? <CopyOutlined /> : <BorderOutlined />}
+                onClick={handleMaximize}
+                className="title-bar-control-button"
+              />
+            </Tooltip>
+            <Tooltip title="关闭">
+              <Button
+                type="text"
+                icon={<CloseOutlined />}
+                onClick={handleClose}
+                className="title-bar-control-button title-bar-close-button"
+              />
+            </Tooltip>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/renderer/src/components/layout/titlebar/titlebar.css
+++ b/src/renderer/src/components/layout/titlebar/titlebar.css
@@ -26,6 +26,11 @@
   padding-left: 8px;
 }
 
+/* macOS: 为原生窗口控制按钮留出空间 */
+.custom-title-bar.mac .title-bar-left {
+  padding-left: 78px; /* 为原生红黄绿按钮留出空间 */
+}
+
 .title-bar-right {
   display: flex;
   align-items: center;


### PR DESCRIPTION
- Use native traffic light buttons on macOS (hiddenInset titleBarStyle)
- Keep custom window controls on Windows/Linux
- Add platform detection API (getPlatform)
- Adjust titlebar padding for native macOS buttons

<img width="1242" height="725" alt="image" src="https://github.com/user-attachments/assets/def4b050-ee8a-43b4-bfd9-59f8466b2c9e" />


close #4 